### PR TITLE
Cambios del 2 de Julio

### DIFF
--- a/laboratorios/internal/templates/internal/inventoryItem/show.html
+++ b/laboratorios/internal/templates/internal/inventoryItem/show.html
@@ -25,23 +25,23 @@
 
                             <div class="form-group">
                               <label>Codigo de la Muestra</label>
-                              <input class="form-control" value={{ inventoryItem.sample.code }} name="SampleCode" disabled="true" type="text">
+                              <input class="form-control" value="{{ inventoryItem.sample.code }}" name="SampleCode" disabled="true" type="text">
                             </div>
                             <div class="form-group">
                               <label>Nombre de la Muestra</label>
-                              <input class="form-control" value={{ inventoryItem.sample.name }} name="SampleName" disabled="true" type="text">
+                              <input class="form-control" value="{{ inventoryItem.sample.name }}" name="SampleName" disabled="true" type="text">
                             </div>
                             <div class="form-group">
                               <label>Tipo de la Muestra</label>
-                              <input class="form-control" value={{ inventoryItem.sample.sample_type.name }} name="TypeName" disabled="true" type="text">
+                              <input class="form-control" value="{{ inventoryItem.sample.sample_type.name }}" name="TypeName" disabled="true" type="text">
                             </div>
                             <div class="form-group">
                               <label>Laboratorio</label>
-                              <input class="form-control" value={{ inventoryItem.sample.inventory.name }} name="SampleLaboratory" disabled="true" type="text">
+                              <input class="form-control" value="{{ inventoryItem.sample.inventory.name }}" name="SampleLaboratory" disabled="true" type="text">
                             </div>
                             <div class="form-group">
                               <label>Estado</label>
-                              <input class="form-control" value={{ inventoryItem.state or 'Almacenado' }} name="SampleState" disabled="true" type="text">
+                              <input class="form-control" value="{{ inventoryItem.state or 'Recién Registrado' }}" name="SampleState" disabled="true" type="text">
                             </div>
                           </div>
                         </div>

--- a/laboratorios/internal/templates/internal/inventoryItem/showRequest.html
+++ b/laboratorios/internal/templates/internal/inventoryItem/showRequest.html
@@ -27,14 +27,22 @@
           </div>
           {% if perms.internal.index_inventoryorder %}
           <div class="col-md-2 col-md-offset-7">
-            {% for data in serviceRequest %}
-            <a class="btn btn-primary pull-right" href="{{ url('internal:inventoryItem.approveAll', data.id ) }}">
-              Aprobar todas las muestras
-            </a>
 
-            <a class="btn btn-primary pull-right" href="{{ url('internal:inventoryItem.changeContract', data.id ) }}">
-              Modificar el contrato
-            </a>
+            {% for data in serviceRequest %}
+
+              {% if validatorApproveAll %}
+                <a class="btn btn-primary pull-right" href="{{ url('internal:inventoryItem.approveAll', data.id ) }}">
+                  Aprobar todas las muestras
+                </a>
+              {% else %}
+                <a class="btn btn-primary pull-right" disabled="True" href="{{ url('internal:inventoryItem.approveAll', data.id ) }}">
+                  No estan todas las muestras
+                </a>
+              {% endif %}
+                <a class="btn btn-primary pull-right" href="{{ url('internal:inventoryItem.changeContract', data.id ) }}">
+                  Modificar el contrato
+                </a>
+
             {% endfor %}
           </div>
           {% endif %}

--- a/laboratorios/internal/templates/internal/inventoryOrder/createPK.html
+++ b/laboratorios/internal/templates/internal/inventoryOrder/createPK.html
@@ -80,10 +80,12 @@
                               <label>Tipo de la Muestra</label>
                               <input class="form-control" value="{{ actualInventoryOrder.sample.sample_type.name }}" name="SampleTypeName" disabled="true" type="text">
                             </div>
+                            <!--
                             <div class="form-group">
                               <label>Laboratorio</label>
                               <input class="form-control" value="{{ actualInventoryOrder.sample.inventory.name }}" name="SampleLaboratory" disabled="true" type="text">
                             </div>
+                            -->
                           </div>
                         </div>
 

--- a/laboratorios/internal/templates/internal/inventoryOrder/edit.html
+++ b/laboratorios/internal/templates/internal/inventoryOrder/edit.html
@@ -74,10 +74,12 @@
                                 <label>Tipo de la Muestra</label>
                                 <input class="form-control" value="{{ inventoryOrder.essay.sample.sample_type.name }}" name="SampleTypeName" disabled="true" type="text">
                               </div>
+                              <!--
                               <div class="form-group">
                                 <label>Laboratorio</label>
                                 <input class="form-control" value="{{ inventoryOrder.essay.sample.inventory.name }}" name="SampleLaboratory" disabled="true" type="text">
                               </div>
+                              -->
                             </div>
                           </div>
 
@@ -148,10 +150,12 @@
                                   <label>Tipo de la Muestra</label>
                                   <input class="form-control" value="{{ newinventoryOrder.sample.sample_type.name }}" name="NewSampleTypeName" disabled="true" type="text">
                                 </div>
+                                <!--
                                 <div class="form-group">
                                   <label>Laboratorio</label>
                                   <input class="form-control" value="{{ newinventoryOrder.sample.inventory.name }}" name="NewSampleLaboratory" disabled="true" type="text">
                                 </div>
+                                -->
                               </div>
                             </div>
                             <div class="ibox">

--- a/laboratorios/internal/templates/internal/inventoryOrder/show.html
+++ b/laboratorios/internal/templates/internal/inventoryOrder/show.html
@@ -56,10 +56,12 @@
                               <label>Tipo de la Muestra</label>
                               <input class="form-control" value="{{ inventoryOrder.essay.sample.sample_type.name }}" name="SampleTypeName" disabled="true" type="text">
                             </div>
+                            <!--
                             <div class="form-group">
                               <label>Laboratorio</label>
                               <input class="form-control" value="{{ inventoryOrder.essay.sample.inventory.name }}" name="SampleLaboratory" disabled="true" type="text">
                             </div>
+                            -->
                           </div>
                         </div>
 

--- a/laboratorios/internal/views/inventoryItem.py
+++ b/laboratorios/internal/views/inventoryItem.py
@@ -85,14 +85,32 @@ def showRequest(request,
         deleted__isnull=True,
         sample__request_id = pk
     ).order_by('sample__name')
+    inventoryItemsIneed = Sample.all_objects.filter(
+        deleted__isnull=True,
+        request_id = pk
+    ).order_by('name')
+
+    validatorApproveAll = True
+    for sampleIneed in inventoryItemsIneed:
+        validatorApproveAll = False
+        for sampleIhave in inventoryItems:
+            if sampleIhave.sample.code == sampleIneed.code:
+                validatorApproveAll = True
+                break
+        if validatorApproveAll == False:
+            break
+
 
     serviceRequest = ServiceRequest.all_objects.filter(
         pk = pk
     ).order_by('client')
 
+
     context = {
         'inventoryItem_list': inventoryItems,
-        'serviceRequest': serviceRequest
+        'SamplesINeed_list': inventoryItemsIneed,
+        'serviceRequest': serviceRequest,
+        'validatorApproveAll': validatorApproveAll
     }
     if extra_context is not None:
         context.update(extra_context)

--- a/laboratorios/internal/views/inventoryOrder.py
+++ b/laboratorios/internal/views/inventoryOrder.py
@@ -66,10 +66,16 @@ def check(request,
 def create(request,
            template='internal/inventoryOrder/create.html'):
     form = InventoryOrderForm(request.POST or None)
+    #Solo puedo crear solicitud de muestras en solicitudes en estado espera de muestras
+    #esta revisando muestras
     context = {
         'essayies': EssayFill.all_objects.filter(
             deleted__isnull=True,
+            sample__request__state__slug = 'wait_for_samples') | EssayFill.all_objects.filter(
+            deleted__isnull=True,
+            sample__request__state__slug = 'review_samples'
         ),
+
     }
     if request.method == 'POST':
         if form.is_valid():
@@ -86,9 +92,14 @@ def createPK(request,
         pk=pk
     )
     form = InventoryOrderForm(request.POST or None)
+    # Solo puedo crear solicitud de muestras en solicitudes en estado espera de muestras
+    # o esta revisando muestras
     context = {
         'essayies': EssayFill.all_objects.filter(
             deleted__isnull=True,
+            sample__request__state__slug = 'wait_for_samples') | EssayFill.all_objects.filter(
+            deleted__isnull=True,
+            sample__request__state__slug = 'review_samples'
         ),
         'actualInventoryOrder': actualInventoryOrder,
     }
@@ -145,7 +156,8 @@ def approve(request, pk, pk2):
 
     #Busco el estado de revisando muestras
     newState = get_object_or_404(
-        ServiceRequestState.all_objects.filter(slug='review_samples'),
+        ServiceRequestState.all_objects.filter(deleted__isnull=True,
+            slug='review_samples'),
     )
 
     #Modifico el estado del la solicitud


### PR DESCRIPTION
Las solicitudes de almacenamiento ahora solo se pueden crear si es que la solicitud esta en estado 'En espera de muestras' o 'Revisión de muestras'.
Se arrelgo el problema de que solo mostraba hasta antes del primer espacio en el show de inventory Item.
Cooincide lo que se muestra cuando no se tiene un estado de muestra almacenada.
Cuando se quieren aprobar todas las muestras en caso que no se tengan todas las muestras almacenadas no te permite hacerle click.